### PR TITLE
Subscribe query destroy bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tuple-database",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tuple-database",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "elen": "^1.0.10",
         "fractional-indexing": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuple-database",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "",
   "repository": "github:ccorcos/tuple-database",
   "main": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "tuple-database",
-  "version": "2.1.4",
-  "description": "",
-  "repository": "github:ccorcos/tuple-database",
-  "main": "./main.js",
-  "scripts": {
-    "build": "run-s build:macros build:tsc",
-    "build:tsc": "tsc",
-    "build:macros": "ts-node src/tools/compileMacros.ts",
-    "watch": "tsc -w",
-    "test": "npm run test:clean && mocha -r ts-node/register './src/**/*.test.ts' --verbose",
-    "test:clean": "rm -rf tmp",
-    "test:watch": "npm test -- --watch --watch-extensions ts",
-    "typecheck": "tsc --project tsconfig.json --noEmit",
-    "prettier": "prettier -w src",
-    "release": "./release.sh"
-  },
-  "devDependencies": {
-    "@types/better-sqlite3": "^5.4.1",
-    "@types/fs-extra": "^9.0.8",
-    "@types/level": "^6.0.0",
-    "@types/lodash": "^4.14.168",
-    "@types/mocha": "whitecolor/mocha-types",
-    "@types/node": "^14.14.31",
-    "@types/react": "^17.0.2",
-    "better-sqlite3": "^7.1.2",
-    "fake-indexeddb": "^3.1.7",
-    "idb": "^7.0.1",
-    "level": "^7.0.1",
-    "mocha": "^8.3.0",
-    "npm-run-all": "^4.1.5",
-    "organize-imports-cli": "^0.9.0",
-    "prettier": "^2.2.1",
-    "react": "^17.0.1",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.4.3"
-  },
-  "peerDependencies": {
-    "react": "*"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    }
-  },
-  "dependencies": {
-    "elen": "^1.0.10",
-    "fractional-indexing": "^1.2.1",
-    "fs-extra": "^9.1.0",
-    "lodash": "^4.17.21",
-    "md5": "^2.3.0",
-    "uuid": "^8.3.2"
-  }
+	"name": "tuple-database",
+	"version": "2.1.4",
+	"description": "",
+	"repository": "github:ccorcos/tuple-database",
+	"main": "./main.js",
+	"scripts": {
+		"build": "run-s build:macros build:tsc",
+		"build:tsc": "tsc",
+		"build:macros": "ts-node src/tools/compileMacros.ts",
+		"watch": "tsc -w",
+		"test": "npm run test:clean && mocha -r ts-node/register './src/**/*.test.ts' --verbose",
+		"test:clean": "rm -rf tmp",
+		"test:watch": "npm test -- --watch --watch-extensions ts",
+		"typecheck": "tsc --project tsconfig.json --noEmit",
+		"prettier": "prettier -w src",
+		"release": "./release.sh"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^5.4.1",
+		"@types/fs-extra": "^9.0.8",
+		"@types/level": "^6.0.0",
+		"@types/lodash": "^4.14.168",
+		"@types/mocha": "whitecolor/mocha-types",
+		"@types/node": "^14.14.31",
+		"@types/react": "^17.0.2",
+		"better-sqlite3": "^7.1.2",
+		"fake-indexeddb": "^3.1.7",
+		"idb": "^7.0.1",
+		"level": "^7.0.1",
+		"mocha": "^8.3.0",
+		"npm-run-all": "^4.1.5",
+		"organize-imports-cli": "^0.9.0",
+		"prettier": "^2.2.1",
+		"react": "^17.0.1",
+		"ts-node": "^9.1.1",
+		"typescript": "^4.4.3"
+	},
+	"peerDependencies": {
+		"react": "*"
+	},
+	"peerDependenciesMeta": {
+		"react": {
+			"optional": true
+		}
+	},
+	"dependencies": {
+		"elen": "^1.0.10",
+		"fractional-indexing": "^1.2.1",
+		"fs-extra": "^9.1.0",
+		"lodash": "^4.17.21",
+		"md5": "^2.3.0",
+		"uuid": "^8.3.2"
+	}
 }

--- a/src/database/sync/subscribeQuery.test.ts
+++ b/src/database/sync/subscribeQuery.test.ts
@@ -38,4 +38,74 @@ describe("subscribeQuery", () => {
 
 		destroy()
 	})
+
+	it.only("doesn't run second callback if it is destroyed in first", async () => {
+		type Schema =
+			| {
+					key: ["filesById", number]
+					value: string
+			  }
+			| {
+					key: ["focusedFileId"]
+					value: number
+			  }
+
+		const db = new TupleDatabaseClient<Schema>(
+			new TupleDatabase(new InMemoryTupleStorage())
+		)
+
+		const initTx = db.transact()
+		initTx.set(["filesById", 1], "file 1 value")
+		initTx.set(["focusedFileId"], 1)
+		initTx.commit()
+
+		let focusedFileValue: string | undefined = undefined
+		let subscription:
+			| { result: string | undefined; destroy: () => void }
+			| undefined = undefined
+
+		function subscribeToFocusedFile(focusedFile: number) {
+			subscription = subscribeQuery(
+				db,
+				(db) => db.get(["filesById", focusedFile]),
+				(value) => {
+					focusedFileValue = value
+				}
+			)
+
+			focusedFileValue = subscription.result
+		}
+
+		let focusedFile: number | undefined = undefined
+
+		const focusedFileQuery = subscribeQuery(
+			db,
+			(db) => db.get(["focusedFileId"])!,
+			(result) => {
+				focusedFile = result
+				subscription?.destroy()
+				subscribeToFocusedFile(result)
+			}
+		)
+
+		focusedFile = focusedFileQuery.result
+
+		assertEqual(focusedFile, 1)
+
+		subscribeToFocusedFile(focusedFile)
+
+		assertEqual(focusedFileValue, "file 1 value")
+
+		const tx = db.transact()
+		tx.remove(["filesById", 1])
+		tx.set(["filesById", 2], "file 2 value")
+		tx.set(["focusedFileId"], 2)
+		tx.commit()
+
+		assertEqual(focusedFile, 2)
+
+		subscribeToFocusedFile(focusedFile)
+
+		assertEqual(focusedFileValue, "file 2 value")
+	})
 })

--- a/src/database/sync/subscribeQuery.test.ts
+++ b/src/database/sync/subscribeQuery.test.ts
@@ -59,6 +59,7 @@ describe("subscribeQuery", () => {
 		initTx.set(["focusedFileId"], 1)
 		initTx.commit()
 
+		let focusedFile: number | undefined = undefined
 		let focusedFileValue: string | undefined = undefined
 		let subscription:
 			| { result: string | undefined; destroy: () => void }
@@ -76,24 +77,20 @@ describe("subscribeQuery", () => {
 			focusedFileValue = subscription.result
 		}
 
-		let focusedFile: number | undefined = undefined
-
 		const focusedFileQuery = subscribeQuery(
 			db,
 			(db) => db.get(["focusedFileId"])!,
 			(result) => {
 				focusedFile = result
 				subscription?.destroy()
-				subscribeToFocusedFile(result)
+				subscribeToFocusedFile(focusedFile)
 			}
 		)
 
 		focusedFile = focusedFileQuery.result
-
-		assertEqual(focusedFile, 1)
-
 		subscribeToFocusedFile(focusedFile)
 
+		assertEqual(focusedFile, 1)
 		assertEqual(focusedFileValue, "file 1 value")
 
 		const tx = db.transact()
@@ -103,9 +100,6 @@ describe("subscribeQuery", () => {
 		tx.commit()
 
 		assertEqual(focusedFile, 2)
-
-		subscribeToFocusedFile(focusedFile)
-
 		assertEqual(focusedFileValue, "file 2 value")
 	})
 })

--- a/src/database/sync/subscribeQuery.ts
+++ b/src/database/sync/subscribeQuery.ts
@@ -82,6 +82,5 @@ export function subscribeQuery<S extends KeyValuePair, T>(
 		resetListeners()
 		destroyed = true
 	}
-
 	return { result, destroy }
 }

--- a/src/database/sync/subscribeQuery.ts
+++ b/src/database/sync/subscribeQuery.ts
@@ -22,6 +22,7 @@ export function subscribeQuery<S extends KeyValuePair, T>(
 	fn: (db: TupleDatabaseClientApi<S>) => Identity<T>,
 	callback: (result: T) => void
 ): Identity<{ result: T; destroy: () => void }> {
+	let destroyed = false
 	const listeners = new Set<any>()
 
 	const compute = () => fn(listenDb)
@@ -34,6 +35,7 @@ export function subscribeQuery<S extends KeyValuePair, T>(
 	let lastComputedTxId: string | undefined
 
 	const recompute = (txId: TxId) => {
+		if (destroyed) return
 		// Skip over duplicate emits.
 		if (txId === lastComputedTxId) return
 
@@ -76,6 +78,10 @@ export function subscribeQuery<S extends KeyValuePair, T>(
 	})
 
 	const result = compute()
-	const destroy = resetListeners
+	const destroy = () => {
+		resetListeners()
+		destroyed = true
+	}
+
 	return { result, destroy }
 }

--- a/src/helpers/naturalSort.test.ts
+++ b/src/helpers/naturalSort.test.ts
@@ -45,12 +45,10 @@ const scientificNotation: ParseTest[] = [
 	["10.20e2", 1020],
 ]
 
-const negativeScientificNotation: ParseTest[] = scientificNotation.map(
-	toNegative
-)
-const positiveScientificNotation: ParseTest[] = scientificNotation.map(
-	toPositive
-)
+const negativeScientificNotation: ParseTest[] =
+	scientificNotation.map(toNegative)
+const positiveScientificNotation: ParseTest[] =
+	scientificNotation.map(toPositive)
 
 const commaNumbers: ParseTest[] = [
 	["1,000", 1000],


### PR DESCRIPTION
The following situation arises in tuple db:

subscribe query A
subscribe query B

some transaction is committed.

callback A is enqueued
callback B is enqueued

query A recomputes, and executes the callback.
In this callback, it destroys query B.
However, query B is still enqueued, so it recomputes and executes its callback anyway (which is probably invalid after query A destroyed it).

This PR fixes that situation.
