### PR TITLE
add type to encodeValue

### DIFF
--- a/src/helpers/codec.ts
+++ b/src/helpers/codec.ts
@@ -23,7 +23,7 @@ export const encodingRank = sortBy(
 	([key, value]) => value
 ).map(([key]) => key as EncodingType)
 
-export function encodeValue(value: Value) {
+export function encodeValue(value: Value): string {
 	if (value === null) {
 		return encodingByte.null
 	}


### PR DESCRIPTION
Before:
```ts
// codec.d.ts
export declare function encodeTuple(tuple: Tuple): any;
```

After:
```ts
// codec.d.ts
export declare function encodeTuple(tuple: Tuple): string;
```

`elen` doesn't have type definitions, so it was returning `any` which propagated down to the type of `encodeTuple`. It would be better just to add types to `elen`, but its docs website doesn't seem to be set up correctly: https://cdn.jsdelivr.net/gh/ealmansi/elen@master/docs/global.html#encode