### PR TITLE
fix type

### DIFF
--- a/src/database/sync/types.test.ts
+++ b/src/database/sync/types.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "mocha"
+import { InMemoryTupleStorage } from "../../main"
+import { TupleDatabase } from "./TupleDatabase"
+import { TupleDatabaseClient } from "./TupleDatabaseClient"
+
+type TestSchema =
+	| {
+			key: [0]
+			value: true
+	  }
+	| {
+			key: [1, string]
+			value: true
+	  }
+
+describe("Type tests", () => {
+	const db = new TupleDatabaseClient<TestSchema>(
+		new TupleDatabase(new InMemoryTupleStorage())
+	)
+
+	it("Root transaction `set` correctly types values", () => {
+		const tx = db.transact()
+
+		// @ts-expect-error
+		tx.set([0], false)
+
+		tx.set([0], true)
+
+		tx.cancel()
+	})
+
+	it("Subspace transaction `set` correctly types values", () => {
+		const tx = db.subspace([1]).transact()
+
+		// @ts-expect-error
+		tx.set(["hello"], false)
+
+		tx.set(["hello"], true)
+
+		tx.cancel()
+	})
+})

--- a/src/database/sync/types.ts
+++ b/src/database/sync/types.ts
@@ -85,9 +85,9 @@ export type TupleRootTransactionApi<S extends KeyValuePair = KeyValuePair> = {
 	) => TupleTransactionApi<RemoveTupleValuePairPrefix<S, P>>
 
 	// WriteApis
-	set: <T extends S>(
-		tuple: T["key"],
-		value: T["value"]
+	set: <Key extends S["key"]>(
+		tuple: Key,
+		value: ValueForTuple<S, Key>
 	) => TupleRootTransactionApi<S>
 	remove: (tuple: S["key"]) => TupleRootTransactionApi<S>
 	write: (writes: WriteOps<S>) => TupleRootTransactionApi<S>

--- a/src/database/sync/types.ts
+++ b/src/database/sync/types.ts
@@ -116,9 +116,9 @@ export type TupleTransactionApi<S extends KeyValuePair = KeyValuePair> = {
 	) => TupleTransactionApi<RemoveTupleValuePairPrefix<S, P>>
 
 	// WriteApis
-	set: <T extends S>(
-		tuple: T["key"],
-		value: T["value"]
+	set: <Key extends S["key"]>(
+		tuple: Key,
+		value: ValueForTuple<S, Key>
 	) => TupleTransactionApi<S>
 	remove: (tuple: S["key"]) => TupleTransactionApi<S>
 	write: (writes: WriteOps<S>) => TupleTransactionApi<S>


### PR DESCRIPTION
Fix `TupleTransactionApi.set` type.

Before, it type-checked to have the wrong value assigned to a tuple:
```ts
type Schema = {
  key: ["0"]
  value: true
} | {
  key: ["1"]
  value: false
}

// ...
// this used to type-check
tx.set(["0"], false)
```

Now, it throws a type error, and the value needs to correspond to the right key.

Am I missing something? Is there a reason this wasn't done already?