### PR TITLE
Adds an `iterate` method that returns a (Async)Generator

### DIFF
--- a/src/database/async/AsyncTupleDatabase.ts
+++ b/src/database/async/AsyncTupleDatabase.ts
@@ -23,6 +23,15 @@ export class AsyncTupleDatabase implements AsyncTupleDatabaseApi {
 		return this.storage.scan({ ...bounds, reverse, limit })
 	}
 
+	iterate(
+		args: ScanStorageArgs = {},
+		txId?: TxId
+	): AsyncGenerator<KeyValuePair> | Generator<KeyValuePair> {
+		const { reverse, limit, ...bounds } = args
+		if (txId) this.log.read(txId, bounds)
+		return this.storage.iterate({ ...bounds, reverse, limit })
+	}
+
 	async subscribe(
 		args: ScanStorageArgs,
 		callback: AsyncCallback

--- a/src/database/async/asyncTypes.ts
+++ b/src/database/async/asyncTypes.ts
@@ -10,6 +10,7 @@ import { ScanArgs, TxId, Unsubscribe } from "../types"
 /** The low-level API for implementing new storage layers. */
 export type AsyncTupleStorageApi = {
 	scan: (args?: ScanStorageArgs) => Promise<KeyValuePair[]>
+	iterate: (args?: ScanStorageArgs) => AsyncGenerator<KeyValuePair>
 	commit: (writes: WriteOps) => Promise<void>
 	close: () => Promise<void>
 }
@@ -17,6 +18,10 @@ export type AsyncTupleStorageApi = {
 /** Wraps AsyncTupleStorageApi with reactivity and MVCC */
 export type AsyncTupleDatabaseApi = {
 	scan: (args?: ScanStorageArgs, txId?: TxId) => Promise<KeyValuePair[]>
+	iterate: (
+		args?: ScanStorageArgs,
+		txId?: TxId
+	) => AsyncGenerator<KeyValuePair> | Generator<KeyValuePair>
 	commit: (writes: WriteOps, txId?: TxId) => Promise<void>
 	cancel: (txId: string) => Promise<void>
 	subscribe: (
@@ -36,6 +41,12 @@ export type AsyncTupleDatabaseClientApi<S extends KeyValuePair = KeyValuePair> =
 			args?: ScanArgs<T, P>,
 			txId?: TxId
 		) => Promise<FilterTupleValuePairByPrefix<S, P>[]>
+		iterate: <T extends S["key"], P extends TuplePrefix<T>>(
+			args?: ScanArgs<T, P>,
+			txId?: TxId
+		) =>
+			| AsyncGenerator<FilterTupleValuePairByPrefix<S, P>>
+			| Generator<FilterTupleValuePairByPrefix<S, P>>
 		subscribe: <T extends S["key"], P extends TuplePrefix<T>>(
 			args: ScanArgs<T, P>,
 			callback: AsyncCallback<FilterTupleValuePairByPrefix<S, P>>

--- a/src/database/async/subscribeQueryAsync.ts
+++ b/src/database/async/subscribeQueryAsync.ts
@@ -56,6 +56,14 @@ export async function subscribeQueryAsync<S extends KeyValuePair, T>(
 			const results = await db.scan(args)
 			return results
 		},
+		iterate: (args: any, txId) => {
+			const destroy = db.subscribe(args, async (_writes, txId) =>
+				recomputeQueue.enqueue(() => recompute(txId))
+			)
+			listeners.add(destroy)
+
+			return db.iterate(args)
+		},
 		cancel: async (txId) => {
 			await db.cancel(txId)
 		},

--- a/src/database/sync/TupleDatabase.ts
+++ b/src/database/sync/TupleDatabase.ts
@@ -27,6 +27,15 @@ export class TupleDatabase implements TupleDatabaseApi {
 		return this.storage.scan({ ...bounds, reverse, limit })
 	}
 
+	iterate(
+		args: ScanStorageArgs = {},
+		txId?: TxId
+	): Identity<Generator<KeyValuePair>> {
+		const { reverse, limit, ...bounds } = args
+		if (txId) this.log.read(txId, bounds)
+		return this.storage.iterate({ ...bounds, reverse, limit })
+	}
+
 	subscribe(args: ScanStorageArgs, callback: Callback): Identity<Unsubscribe> {
 		return this.reactivity.subscribe(args, callback)
 	}

--- a/src/database/sync/TupleDatabaseClient.ts
+++ b/src/database/sync/TupleDatabaseClient.ts
@@ -14,6 +14,7 @@ import {
 	prependPrefixToTuple,
 	prependPrefixToWriteOps,
 	removePrefixFromTuple,
+	removePrefixFromTupleValuePair,
 	removePrefixFromTupleValuePairs,
 	removePrefixFromWriteOps,
 } from "../../helpers/subspaceHelpers"
@@ -49,6 +50,19 @@ export class TupleDatabaseClient<S extends KeyValuePair = KeyValuePair>
 		const pairs = this.db.scan(storageScanArgs, txId)
 		const result = removePrefixFromTupleValuePairs(this.subspacePrefix, pairs)
 		return result as FilterTupleValuePairByPrefix<S, P>[]
+	}
+
+	*iterate<T extends S["key"], P extends TuplePrefix<T>>(
+		args: ScanArgs<T, P> = {},
+		txId?: TxId
+	): Identity<Generator<FilterTupleValuePairByPrefix<S, P>>> {
+		const storageScanArgs = normalizeSubspaceScanArgs(this.subspacePrefix, args)
+		for (const pair of this.db.iterate(storageScanArgs, txId)) {
+			yield removePrefixFromTupleValuePair(
+				this.subspacePrefix,
+				pair
+			) as FilterTupleValuePairByPrefix<S, P>
+		}
 	}
 
 	subscribe<T extends S["key"], P extends TuplePrefix<T>>(

--- a/src/database/sync/databaseTestSuite.ts
+++ b/src/database/sync/databaseTestSuite.ts
@@ -806,6 +806,584 @@ export function databaseTestSuite(
 			}
 		})
 
+		it("iterate gt", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gt: ["a", "a", MAX],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			])
+		})
+
+		it("iterate gt/lt", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gt: ["a", "a", MAX],
+				lt: ["a", "c", MIN],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+			])
+
+			const args2 = {
+				gt: ["a", "b", MIN],
+				lt: ["a", "b", MAX],
+			}
+			const result2: KeyValuePair[] = []
+			for (const pair of store.iterate(args2)) {
+				result2.push(pair)
+			}
+
+			assertEqual(result2, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+			])
+		})
+
+		it("iterate prefix", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				prefix: ["a", "b"],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+			])
+		})
+
+		it("iterate prefix - issue with MAX being true", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: [2, true], value: 1 },
+				{ key: [2, true, 1], value: 1 },
+				{ key: [2, true, true], value: 1 },
+				{ key: [2, true, true, 1], value: 1 },
+				{ key: [2, true, true, true], value: 1 },
+				{ key: [2, true, true, true, 1], value: 1 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				prefix: [2],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, items)
+		})
+
+		it("iterate prefix gte/lte", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "b", "d"], value: 6.5 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				prefix: ["a", "b"],
+				gte: ["b"],
+				lte: ["d"],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "b", "d"], value: 6.5 },
+			])
+		})
+
+		it("iterate prefix gte/lte with schema types", () => {
+			type Schema =
+				| { key: ["a", "a", "a"]; value: 1 }
+				| { key: ["a", "a", "b"]; value: 2 }
+				| { key: ["a", "a", "c"]; value: 3 }
+				| { key: ["a", "b", "a"]; value: 4 }
+				| { key: ["a", "b", "b"]; value: 5 }
+				| { key: ["a", "b", "c"]; value: 6 }
+				| { key: ["a", "b", "d"]; value: 6.5 }
+				| { key: ["a", "c", "a"]; value: 7 }
+				| { key: ["a", "c", "b"]; value: 8 }
+				| { key: ["a", "c", "c"]; value: 9 }
+
+			const store = createStorage<Schema>(randomId())
+
+			const items: Schema[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "b", "d"], value: 6.5 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate({
+				prefix: ["a", "b"],
+				gte: ["b"],
+				lte: ["d"],
+			})) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "b", "d"], value: 6.5 },
+			])
+		})
+
+		it("iterate gte", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gte: ["a", "b", "a"],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			])
+		})
+
+		it("iterate gte/lte", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gte: ["a", "a", "c"],
+				lte: ["a", "c", MAX],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			])
+		})
+
+		it("iterate gte/lte with schema types", () => {
+			type Schema =
+				| { key: ["a", "a", "a"]; value: 1 }
+				| { key: ["a", "a", "b"]; value: 2 }
+				| { key: ["a", "a", "c"]; value: 3 }
+				| { key: ["a", "b", "a"]; value: 4 }
+				| { key: ["a", "b", "b"]; value: 5 }
+				| { key: ["a", "b", "c"]; value: 6 }
+				| { key: ["a", "c", "a"]; value: 7 }
+				| { key: ["a", "c", "b"]; value: 8 }
+				| { key: ["a", "c", "c"]; value: 9 }
+
+			const store = createStorage<Schema>(randomId())
+
+			const items: Schema[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate({
+				gte: ["a", "a", "c"],
+				lte: ["a", "c", MAX],
+			})) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			])
+		})
+
+		it("iterate sorted gt", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gt: ["a", "b", MAX],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			])
+		})
+
+		it("iterate sorted gt/lt", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gt: ["a", "a", MAX],
+				lt: ["a", "b", MAX],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+			])
+		})
+
+		it("iterate sorted gte", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gte: ["a", "b", MIN],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			])
+		})
+
+		it("iterate sorted gte/lte", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			const args = {
+				gte: ["a", "a", "c"],
+				lte: ["a", "b", MAX],
+			}
+			const result: KeyValuePair[] = []
+			for (const pair of store.iterate(args)) {
+				result.push(pair)
+			}
+
+			assertEqual(result, [
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+			])
+		})
+
+		it("iterate invalid bounds", () => {
+			const store = createStorage(randomId())
+
+			const items: KeyValuePair[] = [
+				{ key: ["a", "a", "a"], value: 1 },
+				{ key: ["a", "a", "b"], value: 2 },
+				{ key: ["a", "a", "c"], value: 3 },
+				{ key: ["a", "b", "a"], value: 4 },
+				{ key: ["a", "b", "b"], value: 5 },
+				{ key: ["a", "b", "c"], value: 6 },
+				{ key: ["a", "c", "a"], value: 7 },
+				{ key: ["a", "c", "b"], value: 8 },
+				{ key: ["a", "c", "c"], value: 9 },
+			]
+			const transaction = store.transact()
+			for (const { key, value } of _.shuffle(items)) {
+				transaction.set(key, value)
+			}
+			transaction.commit()
+			const data = store.scan()
+			assertEqual(data, items)
+
+			try {
+				const args = {
+					gte: ["a", "c"],
+					lte: ["a", "a"],
+				}
+				const result: KeyValuePair[] = []
+				for (const pair of store.iterate(args)) {
+					result.push(pair)
+				}
+				assert.fail("Should fail.")
+			} catch (error) {
+				assert.ok(error)
+			}
+		})
+
 		it("stores all types of values", () => {
 			const store = createStorage(randomId())
 			const items: KeyValuePair[] = sortedValues.map(

--- a/src/database/sync/subscribeQuery.ts
+++ b/src/database/sync/subscribeQuery.ts
@@ -64,6 +64,14 @@ export function subscribeQuery<S extends KeyValuePair, T>(
 			const results = db.scan(args)
 			return results
 		},
+		iterate: (args: any, txId) => {
+			const destroy = db.subscribe(args, (_writes, txId) =>
+				recomputeQueue.enqueue(() => recompute(txId))
+			)
+			listeners.add(destroy)
+
+			return db.iterate(args)
+		},
 		cancel: (txId) => {
 			db.cancel(txId)
 		},

--- a/src/database/sync/types.ts
+++ b/src/database/sync/types.ts
@@ -18,6 +18,7 @@ import { ScanArgs, TxId, Unsubscribe } from "../types"
 /** The low-level API for implementing new storage layers. */
 export type TupleStorageApi = {
 	scan: (args?: ScanStorageArgs) => Identity<KeyValuePair[]>
+	iterate: (args?: ScanStorageArgs) => Identity<Generator<KeyValuePair>>
 	commit: (writes: WriteOps) => Identity<void>
 	close: () => Identity<void>
 }
@@ -25,6 +26,10 @@ export type TupleStorageApi = {
 /** Wraps TupleStorageApi with reactivity and MVCC */
 export type TupleDatabaseApi = {
 	scan: (args?: ScanStorageArgs, txId?: TxId) => Identity<KeyValuePair[]>
+	iterate: (
+		args?: ScanStorageArgs,
+		txId?: TxId
+	) => Identity<Generator<KeyValuePair>>
 	commit: (writes: WriteOps, txId?: TxId) => Identity<void>
 	cancel: (txId: string) => Identity<void>
 	subscribe: (
@@ -43,6 +48,10 @@ export type TupleDatabaseClientApi<S extends KeyValuePair = KeyValuePair> = {
 		args?: ScanArgs<T, P>,
 		txId?: TxId
 	) => Identity<FilterTupleValuePairByPrefix<S, P>[]>
+	iterate: <T extends S["key"], P extends TuplePrefix<T>>(
+		args?: ScanArgs<T, P>,
+		txId?: TxId
+	) => Identity<Generator<FilterTupleValuePairByPrefix<S, P>>>
 	subscribe: <T extends S["key"], P extends TuplePrefix<T>>(
 		args: ScanArgs<T, P>,
 		callback: Callback<FilterTupleValuePairByPrefix<S, P>>

--- a/src/helpers/DelayDb.ts
+++ b/src/helpers/DelayDb.ts
@@ -15,6 +15,12 @@ export function DelayDb(
 			await sleep(delay)
 			return db.scan(...args)
 		},
+		iterate: async function* (...args) {
+			for await (const res of db.iterate(...args)) {
+				await sleep(delay)
+				yield res
+			}
+		},
 		commit: async (...args) => {
 			await sleep(delay)
 			return db.commit(...args)

--- a/src/helpers/sortedList.ts
+++ b/src/helpers/sortedList.ts
@@ -40,7 +40,7 @@ type ScanArgs<T> = {
 	reverse?: boolean
 }
 
-export function scan<T>(list: T[], args: ScanArgs<T>, cmp: Compare<T>) {
+function getScanBounds<T>(list: T[], args: ScanArgs<T>, cmp: Compare<T>) {
 	const start = args.gte || args.gt
 	const end = args.lte || args.lt
 
@@ -84,7 +84,27 @@ export function scan<T>(list: T[], args: ScanArgs<T>, cmp: Compare<T>) {
 			? Math.min(lowerSearchBound + args.limit, upperSearchBound)
 			: upperSearchBound
 
+	return { lowerDataBound, upperDataBound }
+}
+
+export function scan<T>(list: T[], args: ScanArgs<T>, cmp: Compare<T>) {
+	const { lowerDataBound, upperDataBound } = getScanBounds(list, args, cmp)
+
 	return args.reverse
 		? list.slice(lowerDataBound, upperDataBound).reverse()
 		: list.slice(lowerDataBound, upperDataBound)
+}
+
+export function* iterate<T>(list: T[], args: ScanArgs<T>, cmp: Compare<T>) {
+	const { lowerDataBound, upperDataBound } = getScanBounds(list, args, cmp)
+
+	if (args.reverse) {
+		for (let i = upperDataBound - 1; i >= lowerDataBound; i--) {
+			yield list[i]
+		}
+	} else {
+		for (let i = lowerDataBound; i < upperDataBound; i++) {
+			yield list[i]
+		}
+	}
 }

--- a/src/helpers/sortedTupleValuePairs.ts
+++ b/src/helpers/sortedTupleValuePairs.ts
@@ -70,3 +70,13 @@ export function scan(data: KeyValuePair[], args: ScanArgs<Tuple, any> = {}) {
 		compareTupleValuePair
 	)
 }
+
+export function iterate(data: KeyValuePair[], args: ScanArgs<Tuple, any> = {}) {
+	const { limit, reverse, ...rest } = args
+	const bounds = normalizeTupleValuePairBounds(rest)
+	return sortedList.iterate(
+		data,
+		{ limit, reverse, ...bounds },
+		compareTupleValuePair
+	)
+}

--- a/src/helpers/subspaceHelpers.ts
+++ b/src/helpers/subspaceHelpers.ts
@@ -75,7 +75,7 @@ function removePrefixFromTuples(prefix: Tuple, tuples: Tuple[]) {
 	return tuples.map((tuple) => removePrefixFromTuple(prefix, tuple))
 }
 
-function removePrefixFromTupleValuePair(
+export function removePrefixFromTupleValuePair(
 	prefix: Tuple,
 	pair: KeyValuePair
 ): KeyValuePair {

--- a/src/storage/InMemoryTupleStorage.ts
+++ b/src/storage/InMemoryTupleStorage.ts
@@ -13,6 +13,10 @@ export class InMemoryTupleStorage implements TupleStorageApi {
 		return tv.scan(this.data, args)
 	}
 
+	iterate(args?: ScanStorageArgs) {
+		return tv.iterate(this.data, args)
+	}
+
 	commit(writes: WriteOps) {
 		// Indexers run inside the tx so we don't need to do that here.
 		// And because of that, the order here should not matter.

--- a/src/storage/LevelTupleStorage.ts
+++ b/src/storage/LevelTupleStorage.ts
@@ -35,6 +35,23 @@ export class LevelTupleStorage implements AsyncTupleStorageApi {
 		return results
 	}
 
+	async *iterate(args: ScanStorageArgs = {}): AsyncGenerator<KeyValuePair> {
+		const dbArgs: any = {}
+		if (args.gt !== undefined) dbArgs.gt = encodeTuple(args.gt)
+		if (args.gte !== undefined) dbArgs.gte = encodeTuple(args.gte)
+		if (args.lt !== undefined) dbArgs.lt = encodeTuple(args.lt)
+		if (args.lte !== undefined) dbArgs.lte = encodeTuple(args.lte)
+		if (args.limit !== undefined) dbArgs.limit = args.limit
+		if (args.reverse !== undefined) dbArgs.reverse = args.reverse
+
+		for await (const [key, value] of this.db.iterator(dbArgs)) {
+			yield {
+				key: decodeTuple(key),
+				value: decodeValue(value),
+			} as KeyValuePair
+		}
+	}
+
 	async commit(writes: WriteOps): Promise<void> {
 		const ops = [
 			...(writes.remove || []).map(

--- a/src/storage/SQLiteTupleStorage.ts
+++ b/src/storage/SQLiteTupleStorage.ts
@@ -3,6 +3,48 @@ import { TupleStorageApi } from "../database/sync/types"
 import { decodeTuple, encodeTuple } from "../helpers/codec"
 import { KeyValuePair, ScanStorageArgs, Tuple, WriteOps } from "./types"
 
+function buildQuery(args: ScanStorageArgs = {}) {
+	// Bounds.
+	let start = args.gte ? encodeTuple(args.gte) : undefined
+	let startAfter: string | undefined = args.gt
+		? encodeTuple(args.gt)
+		: undefined
+	let end: string | undefined = args.lte ? encodeTuple(args.lte) : undefined
+	let endBefore: string | undefined = args.lt ? encodeTuple(args.lt) : undefined
+
+	const sqlArgs = {
+		start,
+		startAfter,
+		end,
+		endBefore,
+		limit: args.limit,
+	}
+
+	const where = [
+		start ? "key >= $start" : undefined,
+		startAfter ? "key > $startAfter" : undefined,
+		end ? "key <= $end" : undefined,
+		endBefore ? "key < $endBefore" : undefined,
+	]
+		.filter(Boolean)
+		.join(" and ")
+
+	let sqlQuery = `select * from data`
+	if (where) {
+		sqlQuery += " where "
+		sqlQuery += where
+	}
+	sqlQuery += " order by key"
+	if (args.reverse) {
+		sqlQuery += " desc"
+	}
+	if (args.limit) {
+		sqlQuery += ` limit $limit`
+	}
+
+	return { sqlArgs, sqlQuery }
+}
+
 export class SQLiteTupleStorage implements TupleStorageApi {
 	/**
 	 * import sqlite from "better-sqlite3"
@@ -45,45 +87,7 @@ export class SQLiteTupleStorage implements TupleStorageApi {
 	private writeFactsQuery: Transaction
 
 	scan = (args: ScanStorageArgs = {}) => {
-		// Bounds.
-		let start = args.gte ? encodeTuple(args.gte) : undefined
-		let startAfter: string | undefined = args.gt
-			? encodeTuple(args.gt)
-			: undefined
-		let end: string | undefined = args.lte ? encodeTuple(args.lte) : undefined
-		let endBefore: string | undefined = args.lt
-			? encodeTuple(args.lt)
-			: undefined
-
-		const sqlArgs = {
-			start,
-			startAfter,
-			end,
-			endBefore,
-			limit: args.limit,
-		}
-
-		const where = [
-			start ? "key >= $start" : undefined,
-			startAfter ? "key > $startAfter" : undefined,
-			end ? "key <= $end" : undefined,
-			endBefore ? "key < $endBefore" : undefined,
-		]
-			.filter(Boolean)
-			.join(" and ")
-
-		let sqlQuery = `select * from data`
-		if (where) {
-			sqlQuery += " where "
-			sqlQuery += where
-		}
-		sqlQuery += " order by key"
-		if (args.reverse) {
-			sqlQuery += " desc"
-		}
-		if (args.limit) {
-			sqlQuery += ` limit $limit`
-		}
+		const { sqlArgs, sqlQuery } = buildQuery(args)
 
 		const results = this.db.prepare(sqlQuery).all(sqlArgs)
 
@@ -94,6 +98,17 @@ export class SQLiteTupleStorage implements TupleStorageApi {
 					value: JSON.parse(value),
 				} as KeyValuePair)
 		)
+	};
+
+	*iterate(args: ScanStorageArgs = {}): Generator<KeyValuePair> {
+		const { sqlArgs, sqlQuery } = buildQuery(args)
+
+		for (const { key, value } of this.db.prepare(sqlQuery).iterate(sqlArgs)) {
+			yield {
+				key: decodeTuple(key) as Tuple,
+				value: JSON.parse(value),
+			} as KeyValuePair
+		}
 	}
 
 	commit = (writes: WriteOps) => {


### PR DESCRIPTION
I don't know if you have a use for this, but there have been a few occasions using this library when I've wanted an `iterate` instead of a `scan`. So this adds PR adds an iterate method both to sync and async clients and store wrappers. I've also added a handful of tests (that are basically just copies of the scan tests). I have not done any checks with respect to reactivity and `iterate`, however.

Thoughts?